### PR TITLE
add support for Edge & IE >= 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@
 
 	let lastWidth, lastHeight;
 
-	shrink.style.cssText = shrinkChild.style.cssText = expand.style.cssText = expandChild.style.cssText = 'clip:rect(0 0 0 0);height:100%;left:0;overflow:hidden;position:absolute;top:0;transition:0s;width:100%;z-index:-1';
+	shrink.style.cssText = expand.style.cssText = 'height:100%;pointer-events:none;opacity:0;left:0;overflow:hidden;position:absolute;top:0;transition:0s;width:100%;z-index:-1';
+	shrinkChild.style.cssText = expandChild.style.cssText = 'display:block;height:100%;transition:0s;width:100%';
 	shrinkChild.style.width = shrinkChild.style.height = '200%';
 
 	element.appendChild(expand);


### PR DESCRIPTION
watch-size worked very well in Chrome & Firefox, but not in IE & Edge. I have slightly tweaked it to improve the compatibility.

I created a pen to demonstrate: https://codepen.io/riophae/pen/bjqqaY

Demo videos:

- IE10 - https://youtu.be/ZQGzW-_aFTQ 
- IE11 - https://youtu.be/PWiXr5BN9fM
- Edge - https://youtu.be/IScAQQq0cgo

Chrome 67 & Firefox 61 have also been tested.
